### PR TITLE
Fix to support falsy value in {{#ifLte}}...{{/ifLte}}

### DIFF
--- a/src/ifLte.js
+++ b/src/ifLte.js
@@ -8,7 +8,7 @@
 export default function ifLte(value, test, options) {
   const self = this; // eslint-disable-line no-invalid-this
 
-  if (!value) {
+  if (!value && value !== 0 && value !== '') { // eslint-disable-line no-magic-numbers
     throw new TypeError('{{#ifLte}}: Argument "value" is required.');
   }
   if (typeof value !== 'string' && typeof value !== 'number') {

--- a/test/ifLte.test.js
+++ b/test/ifLte.test.js
@@ -39,6 +39,19 @@ describe('{{#ifLte value test}}...{{/ifLte}}', () => {
     });
   });
 
+  it('should return comparison result if argument "value" is valid, but falsy. (0 or empty string)', () => {
+    const validFaslyCases = [
+      [0, 100, 'less than equel'],
+      ['', 'a', 'less than equel']
+    ];
+
+    validFaslyCases.forEach(([value, test, expected]) => {
+      const actual = template({value, test});
+
+      assert(actual === expected);
+    });
+  });
+
   it('should return "less than equel" if argument "value" is "a" and argument "test" is "b".', () => {
     const value = 'a',
           test = 'b',


### PR DESCRIPTION
Supports the following cases .

```hbs
{{!--
  value ... 0 or empty string
--}}
{{#ifLte value test}}
  ...
{{/ifLte}}
```